### PR TITLE
Allow ability to turn DGGS cell IDs into DGGS objects for further processing

### DIFF
--- a/auspixdggs/callablemodules/util.py
+++ b/auspixdggs/callablemodules/util.py
@@ -9,3 +9,9 @@ def dggs_cell_id_to_obj(dggs_cell_id):
         input_list.append(int(s))
     cell = rdggs.cell(input_list)
     return cell
+
+def dggs_cell_id_list_to_obj(dggs_cell_id_list):
+    res_list = []
+    for item in dggs_cell_id_list:
+        res_list.append(dggs_cell_id_to_obj(item))
+    return res_list

--- a/auspixdggs/callablemodules/util.py
+++ b/auspixdggs/callablemodules/util.py
@@ -1,0 +1,11 @@
+from ..auspixengine.dggs import RHEALPixDGGS
+rdggs = RHEALPixDGGS() # make an instance
+
+def dggs_cell_id_to_obj(dggs_cell_id):
+    #turn string into list first
+    id_segments = list(dggs_cell_id)
+    input_list = [id_segments.pop(0)]
+    for s in id_segments:
+        input_list.append(int(s))
+    cell = rdggs.cell(input_list)
+    return cell

--- a/tests/enablement/test_cell_id_to_dggs.py
+++ b/tests/enablement/test_cell_id_to_dggs.py
@@ -1,0 +1,14 @@
+import pytest
+from auspixdggs.callablemodules.util import dggs_cell_id_to_obj
+
+
+def test_cell_id_to_cell_obj():
+    # read in the file
+    c = dggs_cell_id_to_obj('R7751215231')
+    print(c)
+    verts = c.vertices(plane=False)
+    vertices = [(138.75323883554336, -34.710999884272056), (138.75476299344612, -34.710999884272056), (138.75476299344612, -34.712573832391016), (138.75323883554336, -34.712573832391016)]
+    assert verts == vertices
+    
+if __name__ == "__main__":
+    test_cell_id_to_cell_obj()


### PR DESCRIPTION
Adds a util module and code to allow ability to turn DGGS cell IDs (or lists of DGGS Cell IDs) into DGGS objects for further processing