### PR TITLE
Repo citation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,27 +1,4 @@
- AusPIX_DGGS
- The Geoscience Australia rHealPIX version of the DGGS engine
- 
- Copyright 2020 Geoscience Australia
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-
-
-
-
-
-
-Apache License
+                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AusPIX
 AusPIX is an Australian Government implimentation of the rHealpix DGGS. 
 
-AusPIX specifies the starting points of the rHealpix top-level cells to achineve some Australian aims, such as including most of the Australian continent within once cell.
+AusPIX specifies the starting points of the rHEALPix top-level cells to achineve some Australian aims, such as including most of the Australian continent within once cell.
 
 This repository contains the rHealPIX "engine" and a series of scripts that use AusPIX in a variety of ways.
 There are several 'callable' modules that perform common tasks in DGGS space. These are in the "callable_modules" folder.
@@ -48,11 +48,11 @@ Some speed enhancements by CSIRO under contract, Funded by the Australian Govern
 
 Initial guidance by Matt Purss, formerly based at Geosciece Australia.
 
-rHealPIX DGGS engine developed by Gibb, R.G _et al._
+rHEALPix DGGS engine developed by Gibb, R.G _et al._
 
-Source references for rHealPIX:
+Source references for rHEALPix:
 
-* Gibb, R.G. (2016) "The rHealPIX Discrete Global Grid System" Proceedings of the 9th Symposium of the International Society for Digital Earth (ISDE), Halifax, Nova Scotia, Canada. IOP Conf. Series: Earth and Environmental Science, 34, 012012. DOI: [10.1088/1755-1315/34/1/012012](https://doi.org/10.1088/1755-1315/34/1/012012)
+* Gibb, R.G. (2016) "The rHEALPix Discrete Global Grid System" Proceedings of the 9th Symposium of the International Society for Digital Earth (ISDE), Halifax, Nova Scotia, Canada. IOP Conf. Series: Earth and Environmental Science, 34, 012012. DOI: [10.1088/1755-1315/34/1/012012](https://doi.org/10.1088/1755-1315/34/1/012012)
 * Gibb R G, Raichev A and Speth M (2013) "The rHEALPix Discrete Global Grid System" DOI: [10.7931/J2D21VHM](https://doi.org/10.7931/J2D21VHM).
 
 
@@ -68,7 +68,7 @@ Please cite this work with the following BibTex description:
 
 ```bibtex
 @software{AusPIX_DGGS,
-  title = {{AusPIX: An Australian Government implimentation of the rHealpix DGGS in Python}},
+  title = {{AusPIX: An Australian Government implimentation of the rHEALPix DGGS in Python}},
   date = {2020},
   publisher = "Geoscience Australia",
   url = {https://github.com/GeoscienceAustralia/AusPIX_DGGS}

--- a/README.md
+++ b/README.md
@@ -1,40 +1,22 @@
-# AusPIX_DGGS
-The AusPIX DGGS is an Australian Government implimentation of the rHealpix DGGS engine.
+# AusPIX
+AusPIX is an Australian Government implimentation of the rHealpix DGGS. 
 
-Date: June 2019
+AusPIX specifies the starting points of the rHealpix top-level cells to achineve some Australian aims, such as including most of the Australian continent within once cell.
 
-Included in this repository is the rHealPIX "engine" and a series of scripts that use AusPIX in a variety of ways.
+This repository contains the rHealPIX "engine" and a series of scripts that use AusPIX in a variety of ways.
 There are several 'callable' modules that perform common tasks in DGGS space. These are in the "callable_modules" folder.
 
-Wrapper scripts developed by Bell, J.G. at Geoscience Australia.
-Geoscience eCat record: https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/140148
 
-Some speed enhancements by CSIRO under contract.
+## Grid Imagery
+The following images show the structure and positioning of the AusPIX grid relative to the earth's globe.
 
-Funded by the Australian Government Loc-I Project
+![rhealpix](https://user-images.githubusercontent.com/23160509/53066271-23aa4680-3523-11e9-8e6c-2f042f9befbf.png)  
+Figure 1: World Grid layout.
 
-Initial guidance by Matt Purss
-
-rHealPIX DGGS engine developed by Gibb, R.G et al
-
-Source references for rHealPIX:
-
-Gibb, R.G., 2016, “The rHealPIX Discrete Global Grid System” Proceedings of the 9th Symposium of the International Society for Digital Earth (ISDE), Halifax, Nova Scotia, Canada. IOP Conf. Series: Earth and Environmental Science, 34, 012012. DOI: 10.1088/1755-1315/34/1/012012
-
-Gibb R G, Raichev A and Speth M 2013 The rHEALPix Discrete Global Grid System URL http://dx.doi.org/10.7931/J2D21VHM
-
-
-
-
-![rhealpix](https://user-images.githubusercontent.com/23160509/53066271-23aa4680-3523-11e9-8e6c-2f042f9befbf.png)
-Figure 1: World Grid layout:
-
-![maindggsregions](https://user-images.githubusercontent.com/23160509/53380635-35c43300-39c2-11e9-90ea-e457d03b8726.png)
-
+![maindggsregions](https://user-images.githubusercontent.com/23160509/53380635-35c43300-39c2-11e9-90ea-e457d03b8726.png)  
 Figure 2: Major AusPIX divisions in the Australian region.
 
-![auspixlevel10](https://user-images.githubusercontent.com/23160509/53381199-1cbc8180-39c4-11e9-86d2-8a7a12b50faf.png)
-
+![auspixlevel10](https://user-images.githubusercontent.com/23160509/53381199-1cbc8180-39c4-11e9-86d2-8a7a12b50faf.png)  
 Figure 3:  Sample AusPIX level 10 cells (approx 140 x 140 m) near the lake in Canberra.
 
 
@@ -49,7 +31,7 @@ or for development
 or   
 `pip install -e .`
 
-## Running tests
+### Running tests
 
 ``` 
 $ pip install pytests
@@ -57,3 +39,46 @@ $ python -m pytests tests/
 ```
 
 
+## Development History
+
+Wrapper scripts developed by Bell, J.G. at Geoscience Australia are catalogued with the follwing Geoscience eCat record: 
+* <http://pid.geoscience.gov.au/dataset/ga/140148>
+
+Some speed enhancements by CSIRO under contract, Funded by the Australian Government [Location Index Project](https://www.ga.gov.au/locationindex).
+
+Initial guidance by Matt Purss, formerly based at Geosciece Australia.
+
+rHealPIX DGGS engine developed by Gibb, R.G _et al._
+
+Source references for rHealPIX:
+
+* Gibb, R.G. (2016) "The rHealPIX Discrete Global Grid System" Proceedings of the 9th Symposium of the International Society for Digital Earth (ISDE), Halifax, Nova Scotia, Canada. IOP Conf. Series: Earth and Environmental Science, 34, 012012. DOI: [10.1088/1755-1315/34/1/012012](https://doi.org/10.1088/1755-1315/34/1/012012)
+* Gibb R G, Raichev A and Speth M (2013) "The rHEALPix Discrete Global Grid System" DOI: [10.7931/J2D21VHM](https://doi.org/10.7931/J2D21VHM).
+
+
+## License & Rights
+
+Software in this repository is licensed for use under the [Apache 2.0 Software License](), a copy of the deed of which is contained in the [LICENSE](LICENSE) file.
+
+This work is copyright: &copy; Australian Government (Geosicence Australia), 2020.
+
+
+## Citation
+Please cite this work with the following BibTex description:
+
+```bibtex
+@software{AusPIX_DGGS,
+  title = {{AusPIX: An Australian Government implimentation of the rHealpix DGGS in Python}},
+  date = {2020},
+  publisher = "Geoscience Australia",
+  url = {https://github.com/GeoscienceAustralia/AusPIX_DGGS}
+}
+```
+
+## Contact
+
+**Joseph G. Bell**  
+_Geospatial Data Scientist_  
+National Land Information,  
+Geosciece Australia  
+<joseph.bell@ga.gov.au>


### PR DESCRIPTION
This PR just tidies up the README and LICENSE files to allow for better citations of the AusPIX system. This is needed now since AusPIX is being cited in examples within the OGC's GeoSPARQL standard.